### PR TITLE
set os installer download url to release.aosc.io

### DIFF
--- a/src/app/downloadmanager.cpp
+++ b/src/app/downloadmanager.cpp
@@ -86,7 +86,7 @@ QString DownloadManager::downloadFile(DownloadReceiver *receiver, const QString 
     m_mirrorCache.clear();
 
     QString s;
-    s.push_back("https://mirrors.qvq.net.cn/anthon/aosc-os/");
+    s.push_back("https://releases.aosc.io/");
     s.push_back(url);
     m_mirrorCache << s;
 


### PR DESCRIPTION
QVQNetwork 开源软件镜像服务将于 2024/11/01 停止服务，故调整启动盘制作向导内下载来源为 `release.aosc.io`，QVQ 方通知如下：

> 关于 mirrors.qvq.net.cn 镜像服务即将关闭的通知
> 
> 大家好：
> 
> 由于对中国监管环境变化和不确定性的担忧，我们不得不做出一个艰难的决定：关闭 QVQNetwork 开源软件镜像服务。
> QVQNetwork开源软件镜像站 将于 2024 年 11 月 1 日 正式停止服务。
> 届时，您将无法再通过 mirrors.qvq.net.cn 访问任何开源软件镜像。
> 
> 我们对由此可能给您带来的不便深表歉意，感谢您一直以来对我们的支持与理解！
> 
> 此致，
> QVQNetwork开源软件镜像站
> 2024年10月26日

